### PR TITLE
Feature/unit discount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Prop `unitPriceDisplay` to `unit-price` block.
+- Prop `displayListPrice` to `unit-price` block.
+
 ## [0.19.1] - 2020-03-16
 
 ## [0.19.0] - 2020-03-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Prop `unitPriceDisplay` to `unit-price` block.
-- Prop `displayListPrice` to `unit-price` block.
+- Prop `displayUnitListPrice` to `unit-price` block.
 
 ## [0.19.1] - 2020-03-16
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -206,10 +206,10 @@ By default implementation we mean that whenever you use `product-list` in your s
 
 Therefore, in order to customize the Product List configuration, you can simply use the default implementation in your code and change it as you wish.
 
-| Prop name          | Type   | Description                                                                                                                                   | Default value |
-| ------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `unitPriceDisplay` | `Enum` | Determines if the unit price should always appear or appears only when the product quantity is bigger than one. (values: `always`, `default`) | `'default'`   |
-| `displayListPrice` | `Enum` | Display the unit list price when it's different from price. (values: `'always'` or `'never'`)                                                 | `'never'`     |
+| Prop name              | Type   | Description                                                                                                                                   | Default value |
+| ---------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `unitPriceDisplay`     | `Enum` | Determines if the unit price should always appear or appears only when the product quantity is bigger than one. (values: `always`, `default`) | `'default'`   |
+| `displayUnitListPrice` | `Enum` | Display the unit list price when it's different from price. (values: `'always'` or `'never'`)                                                 | `'never'`     |
 
 ## Customization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -210,6 +210,7 @@ Therefore, in order to customize the Product List configuration, you can simply 
 | ---------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `unitPriceDisplay`     | `Enum` | Determines if the unit price should always appear or appears only when the product quantity is bigger than one. (values: `always`, `default`) | `'default'`   |
 | `displayUnitListPrice` | `Enum` | Display the unit list price when it's different from price. (values: `'always'` or `'never'`)                                                 | `'never'`     |
+| `textAlign`            | `Enum` | Enable to set a text alignment. (values: `'left'`. `'center'` or `'right'` )                                                                  | `''`          |
 
 ## Customization
 
@@ -242,6 +243,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `removeButtonContainer`              |
 | `removeButton`                       |
 | `unitPriceContainer`                 |
+| `unitListPrice`                      |
 | `unitPriceMeasurementUnit`           |
 | `unitPricePerUnitCurrency`           |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -206,6 +206,11 @@ By default implementation we mean that whenever you use `product-list` in your s
 
 Therefore, in order to customize the Product List configuration, you can simply use the default implementation in your code and change it as you wish.
 
+| Prop name          | Type   | Description                                                                                                                                   | Default value |
+| ------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `unitPriceDisplay` | `Enum` | Determines if the unit price should always appear or appears only when the product quantity is bigger than one. (values: `always`, `default`) | `'default'`   |
+| `displayListPrice` | `Enum` | Display the unit list price when it's different from price. (values: `'always'` or `'never'`)                                                 | `'never'`     |
+
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).

--- a/react/UnitPrice.tsx
+++ b/react/UnitPrice.tsx
@@ -17,17 +17,17 @@ const CSS_HANDLES = [
 
 interface UnitPriceProps extends TextAlignProp {
   unitPriceDisplay: UnitPriceDisplayType
-  displayListPrice: DisplayListPriceType
+  displayUnitListPrice: DisplayUnitListPriceType
 }
 
 type UnitPriceDisplayType = 'always' | 'default'
 
-type DisplayListPriceType = 'always' | 'never'
+type DisplayUnitListPriceType = 'always' | 'never'
 
 const UnitPrice: StorefrontFunctionComponent<UnitPriceProps> = ({
   textAlign,
   unitPriceDisplay = 'default',
-  displayListPrice = 'never',
+  displayUnitListPrice = 'never',
 }) => {
   const { item, loading } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
@@ -44,7 +44,7 @@ const UnitPrice: StorefrontFunctionComponent<UnitPriceProps> = ({
         styles.quantity
       } ${opaque(item.availability)} ${parseTextAlign(textAlign)}`}
     >
-      {item.price !== item.listPrice && displayListPrice === 'always' && (
+      {item.price !== item.listPrice && displayUnitListPrice === 'always' && (
         <div className={`strike ${handles.unitListPrice}`}>
           <FormattedCurrency value={item.listPrice / 100} />
         </div>

--- a/react/UnitPrice.tsx
+++ b/react/UnitPrice.tsx
@@ -14,8 +14,18 @@ const CSS_HANDLES = [
   'unitPriceMeasurementUnit',
 ] as const
 
-const UnitPrice: StorefrontFunctionComponent<TextAlignProp> = ({
+interface UnitPriceProps extends TextAlignProp {
+  unitPriceDisplay: UnitPriceDisplayType
+  displayListPrice: DisplayListPriceType
+}
+
+type UnitPriceDisplayType = 'always' | 'default'
+
+type DisplayListPriceType = 'always' | 'never'
+
+const UnitPrice: StorefrontFunctionComponent<UnitPriceProps> = ({
   textAlign,
+  unitPriceDisplay = 'default',
 }) => {
   const { item, loading } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
@@ -24,7 +34,8 @@ const UnitPrice: StorefrontFunctionComponent<TextAlignProp> = ({
     return null
   }
 
-  return item.quantity > 1 && item.sellingPrice > 0 ? (
+  return (item.quantity > 1 || unitPriceDisplay === 'always') &&
+    item.sellingPrice > 0 ? (
     <div
       id={`unit-price-${item.id}`}
       className={`t-mini c-muted-1 lh-title ${handles.unitPriceContainer} ${

--- a/react/UnitPrice.tsx
+++ b/react/UnitPrice.tsx
@@ -12,6 +12,7 @@ const CSS_HANDLES = [
   'unitPriceContainer',
   'unitPricePerUnitCurrency',
   'unitPriceMeasurementUnit',
+  'unitListPrice',
 ] as const
 
 interface UnitPriceProps extends TextAlignProp {
@@ -26,6 +27,7 @@ type DisplayListPriceType = 'always' | 'never'
 const UnitPrice: StorefrontFunctionComponent<UnitPriceProps> = ({
   textAlign,
   unitPriceDisplay = 'default',
+  displayListPrice = 'never',
 }) => {
   const { item, loading } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
@@ -42,6 +44,11 @@ const UnitPrice: StorefrontFunctionComponent<UnitPriceProps> = ({
         styles.quantity
       } ${opaque(item.availability)} ${parseTextAlign(textAlign)}`}
     >
+      {item.price !== item.listPrice && displayListPrice === 'always' && (
+        <div className={`strike ${handles.unitListPrice}`}>
+          <FormattedCurrency value={item.listPrice / 100} />
+        </div>
+      )}
       <FormattedMessage
         id="store/product-list.pricePerUnit"
         values={{


### PR DESCRIPTION
#### What problem is this solving?

Add `unitPriceDisplay` and `displayListPrice` props to `proiduct-list` to show the unit price even when product quantity is one and to display unit list price, respectively.

#### How should this be manually tested?

Add the prop to the product-list block.
Workspace for tests: https://unitprice--acctglobal.myvtex.com/

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Example in blocks: https://i.imgur.com/UTDFXKz.png
Unit price appear even when product quantity is one: https://i.imgur.com/LUCyjK6.png
Unit list price appears above unit price: https://i.imgur.com/LUCyjK6.png

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
